### PR TITLE
fix: Fix crash issues when /sys/class/backlight directory is empty

### DIFF
--- a/src/brightnessApplet.cpp
+++ b/src/brightnessApplet.cpp
@@ -40,7 +40,7 @@ void BrightnessApplet::initUI()
     m_titleLabel->setForegroundRole(QPalette::BrightText);
     Dtk::Widget::DFontSizeManager::instance()->bind(m_titleLabel, Dtk::Widget::DFontSizeManager::T4, QFont::Medium);
     // 亮度 Label
-    m_infoLabel->setText(QString("%1%").arg(0));
+    m_infoLabel->setText(QString("%1 %").arg(0));
     m_infoLabel->setFixedHeight(TITLE_HEIGHT);
     m_infoLabel->setForegroundRole(QPalette::BrightText);
     Dtk::Widget::DFontSizeManager::instance()->bind(m_infoLabel, Dtk::Widget::DFontSizeManager::T8, QFont::Medium);
@@ -66,8 +66,14 @@ void BrightnessApplet::initUI()
     slider->setFixedHeight(SLIDER_HIGHT);
 
 //    slider->setValue(m_backLightInfoList->value(CURDEVICEINDEX).curBrightness * 100 / m_backLightInfoList->value(CURDEVICEINDEX).maxBrightness);
-    slider->setValue(BrightnessUtil::getBackLightPercentage());
-    m_infoLabel->setText(QString::number(slider->value()) + " %");
+    int percentage = BrightnessUtil::getBackLightPercentage();
+    if (percentage < 0) {
+        qCritical() << "Get backlight percentage failed, disabling brightness adjustment...";
+        slider->setDisabled(true);
+        percentage = 0;
+    }
+    slider->setValue(percentage);
+    m_infoLabel->setText(QString::number(percentage) + " %");
 
     QHBoxLayout *sliderLayout = new QHBoxLayout;
     sliderLayout->setSpacing(0);

--- a/src/brightnessplugin.cpp
+++ b/src/brightnessplugin.cpp
@@ -18,6 +18,8 @@ BrightnessPlugin::BrightnessPlugin(QObject *parent)
 //                     m_brightnessApplet, SLOT(setBackLight(const int)));
 //    QObject::connect(m_brightnessWidget, SIGNAL(wheelEventTip()),
 //                     this, SLOT(handleEventTip()));
+
+    m_tipsWidget->setContentsMargins(10, 0, 10, 0);
     }
 
 /**
@@ -70,7 +72,7 @@ QWidget *BrightnessPlugin::itemWidget(const QString &itemKey)
 QWidget *BrightnessPlugin::itemTipsWidget(const QString &itemKey)
 {
     BackLightInfo brightnessInfo = m_brightnessApplet->getCurBackLight();
-    m_tipsWidget->setText(QString(" 当前亮度 %1% ").arg((brightnessInfo.curBrightness * 100 /  brightnessInfo.maxBrightness) + 1));
+    m_tipsWidget->setText(QString("当前亮度 %1 %").arg(qCeil(brightnessInfo.curBrightness * 100 /  brightnessInfo.maxBrightness)));
     return m_tipsWidget;
 }
 /**

--- a/src/common/brightnessutil.cpp
+++ b/src/common/brightnessutil.cpp
@@ -72,5 +72,9 @@ bool BrightnessUtil::setBrightness(const std::string &backlight, int value) {
  */
 int BrightnessUtil::getBackLightPercentage() {
     QList<BackLightInfo> backLightInfo = getBackLightInfo();
+    if (backLightInfo.size() < 1) {
+        return -1;
+    }
+
     return (backLightInfo.value(CURDEVICEINDEX).curBrightness * 100 / backLightInfo.value(CURDEVICEINDEX).maxBrightness) + 1;
 }

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -5,7 +5,7 @@
 
 struct BackLightInfo {
   QString name;
-  int curBrightness;
-  int maxBrightness;
+  int curBrightness = 0;
+  int maxBrightness = 1;
 };
 #endif // COMMON_H


### PR DESCRIPTION
When /sys/class/backlight directory is empty, BrightnessUtil::getBackLightInfo returns empty list. However, curBrightness and maxBrightness in struct BackLightInfo is not initialized, 0 / 0 may happens, which causes crash

Log: BrightnessUtil::getBackLightPercentage returns -1 when /sys/class/backlight directory is empty, and disable slider at the same time